### PR TITLE
Linkify mention of future_lapply()

### DIFF
--- a/R/future_apply.R
+++ b/R/future_apply.R
@@ -16,7 +16,7 @@
 #' dimension names.
 #' 
 #' @param \ldots  (optional) Additional arguments passed to `FUN()`, except
-#' `future.*` arguments, which are passed on to `future_lapply()` used
+#' `future.*` arguments, which are passed on to [future_lapply()] used
 #' internally.
 #' 
 #' @param simplify a logical indicating whether results should be simplified


### PR DESCRIPTION
It might be nice if some of the sections from `future_lapply()` were inherited in `future_apply()`. E.g., the "Reproducible random number generation (RNG)". Because at the moment, the docs of `future_apply()` say "For details, see below section." when there is nothing below.